### PR TITLE
Add issue regarding Fig plugin in PyCharm

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ All shell profiles and settings, and plugins can be backed up to your Fig accoun
 ##### Issues
 
 - For an error about `.zshenv` not being found when launching the terminal in PyCharm, try the solution here: <https://github.com/withfig/fig/issues/2232#issuecomment-1497465713>
+- When hovering over an element in PyCharm fails to pop up with the tooltip, see this issue: <https://github.com/withfig/fig/issues/2357>
 
 ### Python
 


### PR DESCRIPTION
With the Fig plugin (v2.0.0) in PyCharm, it forces the **Support screen reader** toggle in the settings to be on. This disables the functionality to get object definitions as a popup when hovering over an element

To fix, the Fig plugin needs to be disabled. Then **Support screen reader** can be toggled off and the popup works 